### PR TITLE
Potential fix for code scanning alert no. 6: Client-side cross-site scripting

### DIFF
--- a/src/app/(app)/production/[id]/page.tsx
+++ b/src/app/(app)/production/[id]/page.tsx
@@ -111,9 +111,22 @@ function PlanContent({
 }) {
   const [backHref, setBackHref] = useState("/production");
   const [backLabel, setBackLabel] = useState("Production");
+
+  const sanitizeBackHref = (value: string | null): string | null => {
+    if (!value) return null;
+    if (!value.startsWith("/") || value.startsWith("//")) return null;
+    try {
+      const parsed = new URL(value, window.location.origin);
+      if (parsed.origin !== window.location.origin) return null;
+      return `${parsed.pathname}${parsed.search}${parsed.hash}`;
+    } catch {
+      return null;
+    }
+  };
+
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const from = params.get("from");
+    const from = sanitizeBackHref(params.get("from"));
     if (from) { setBackHref(from); setBackLabel("Back to product"); }
     const tab = params.get("tab") as PhaseId | null;
     if (tab && PHASES.some((p) => p.id === tab)) setActivePhase(tab);

--- a/src/app/(app)/production/[id]/summary/page.tsx
+++ b/src/app/(app)/production/[id]/summary/page.tsx
@@ -12,8 +12,16 @@ export default function BatchSummaryPage() {
   const [copied, setCopied] = useState(false);
   const [backHref, setBackHref] = useState("/production");
   const [backLabel, setBackLabel] = useState("Back to batch");
+
+  const sanitizeBackHref = (value: string | null): string | null => {
+    if (!value) return null;
+    if (!value.startsWith("/")) return null;
+    if (value.startsWith("//")) return null;
+    return value;
+  };
+
   useEffect(() => {
-    const from = new URLSearchParams(window.location.search).get("from");
+    const from = sanitizeBackHref(new URLSearchParams(window.location.search).get("from"));
     if (from === "/production") { setBackHref(from); setBackLabel("Production"); }
     else if (from) { setBackHref(from); setBackLabel("Back to product"); }
     else if (planId) { setBackHref(`/production/${planId}`); }


### PR DESCRIPTION
Potential fix for [https://github.com/choc-collab/app/security/code-scanning/6](https://github.com/choc-collab/app/security/code-scanning/6)

The safest fix is to validate and normalize the `from` query parameter before assigning it to `backHref`, allowing only internal app-relative paths and rejecting everything else.

Best minimal change in `src/app/(app)/production/[id]/page.tsx`:
- Add a small local helper (inside the component, near the `useEffect`) to sanitize candidate href values.
- Accept only strings that start with `/` and do **not** start with `//` (protocol-relative external), and optionally ensure they parse as same-origin paths.
- If invalid, fall back to the existing safe default (`"/production"`).
- Use sanitized value in line 117 logic before calling `setBackHref`.

No new dependency is required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
