### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/choc-collab/app/security/code-scanning/7](https://github.com/choc-collab/app/security/code-scanning/7)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege defaults.  
For this workflow, `contents: read` is the minimum needed for `actions/checkout`. The `e2e` job uploads an artifact using `actions/upload-artifact`, which requires `actions: write`, so include that as well to avoid breaking functionality.

Best single fix (without changing behavior): insert after `on:` triggers and before `jobs:`:

- `permissions:`
  - `contents: read`
  - `actions: write`

This keeps both jobs functioning while explicitly limiting token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
