### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Potential fix for [https://github.com/choc-collab/app/security/code-scanning/8](https://github.com/choc-collab/app/security/code-scanning/8)

Add an explicit workflow-level `permissions` block so all jobs inherit least-privilege defaults. The minimal and appropriate permission here is:

- `contents: read`

This supports `actions/checkout` while avoiding unnecessary write scopes. Since neither job needs repository writes, no additional scopes are required.  
Edit `.github/workflows/ci.yml` near the top-level keys: insert `permissions:` after the `on:` block (before `jobs:`) to apply to both `build-and-test` and `e2e` without changing workflow behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
